### PR TITLE
The SpinnakerWebserver in publicSubnet

### DIFF
--- a/templates/quickstart-spinnakercf.template
+++ b/templates/quickstart-spinnakercf.template
@@ -592,7 +592,7 @@
                 },
                 "NetworkInterfaces": [
                     {
-                        "AssociatePublicIpAddress": "true",
+                        "AssociatePublicIpAddress": "false",
                         "DeviceIndex": "0",
                         "GroupSet": [
                             {
@@ -600,7 +600,7 @@
                             }
                         ],
                         "SubnetId": {
-                            "Ref": "SpinnakerPublicSubnet"
+                            "Ref": "SpinnakerPrivateSubnet"
                         }
                     }
                 ],


### PR DESCRIPTION
Remove the public IP from the webserver and move it from the public subnet into the private.